### PR TITLE
fix: use forced npm install for recharts

### DIFF
--- a/.github/workflows/host_ui_frontend.yml
+++ b/.github/workflows/host_ui_frontend.yml
@@ -270,7 +270,7 @@ jobs:
         - name: Build Storybok
           if: ${{inputs.build_project_type == 'storybook'}}
           run: |
-            npm ci
+            npm install --force
             NODE_ENV=development npx nx build-storybook ui-components
 
         # Read commit message and determine if to skip cdk work NODE_ENV=development && npx nx build-storybook ui-components

--- a/.github/workflows/host_ui_frontend.yml
+++ b/.github/workflows/host_ui_frontend.yml
@@ -270,7 +270,7 @@ jobs:
         - name: Build Storybok
           if: ${{inputs.build_project_type == 'storybook'}}
           run: |
-            npm install --force
+            npm ci
             NODE_ENV=development npx nx build-storybook ui-components
 
         # Read commit message and determine if to skip cdk work NODE_ENV=development && npx nx build-storybook ui-components
@@ -361,7 +361,7 @@ jobs:
         - name: Build nx Frontend
           if: ${{inputs.build_project_type == 'nx'}}
           run: |
-            npm ci
+            npm install --force
             if [[ ${BRANCH_NAME} == 'main' ]]
             then
               npx nx build


### PR DESCRIPTION
We have a 3rd party dependency (recharts) on the frontend that doesn't currently pass npm validation for version compatibility. We've tested it thought and would like to force npm to install it anyways for the time being. There's some work being done to resolve the version compatibility issue and once that's been fixed we can undo this change